### PR TITLE
fix(SkinCitizen_CSS): 修复工具栏样式和图片背景色问题

### DIFF
--- a/src/SkinCitizen_CSS/SkinCitizen_CSS.less
+++ b/src/SkinCitizen_CSS/SkinCitizen_CSS.less
@@ -21,4 +21,4 @@
 @import './modules/visualeditor.less';
 @import './modules/wikilove.less';
 @import './modules/fix-toolbar.less';
-@import './modules/patch-one.less'
+@import './modules/patch-one.less';

--- a/src/SkinCitizen_CSS/modules/fix-toolbar.less
+++ b/src/SkinCitizen_CSS/modules/fix-toolbar.less
@@ -6,10 +6,8 @@
 }
 
 // 更新toolbar样式，防止在无内容时显示。 by awajie
-#contentSub {
-	.subpages {
-		.toolbar-fix();
-	}
+#mw-content-subtitle {
+	.toolbar-fix();
 	&:empty {
 		display: none;
 	}

--- a/src/SkinCitizen_CSS/modules/patch-one.less
+++ b/src/SkinCitizen_CSS/modules/patch-one.less
@@ -1,13 +1,13 @@
 // 修复图片背景色。 by awajie
 .client-darkmode {
-  &[typeof~='mw:File'] img,
-  &[typeof~='mw:File/Thumb'] img,
-  &[typeof~='mw:File/Frame'] img,
-  &[typeof~='mw:File/Frameless'] img,
-  .mw-halign-left img,
-  .mw-halign-right img,
-  .mw-halign-center img {
-    width: auto;
-    background: rgba(0, 0, 0, 0) !important;
-  }
+	[typeof~='mw:File'] img,
+	[typeof~='mw:File/Thumb'] img,
+	[typeof~='mw:File/Frame'] img,
+	[typeof~='mw:File/Frameless'] img,
+	.mw-halign-left img,
+	.mw-halign-right img,
+	.mw-halign-center img {
+		width: auto;
+		background: rgba(0, 0, 0, 0) !important;
+	}
 }


### PR DESCRIPTION
- 修复了工具栏样式，防止在无内容时显示
- 优化了图片背景色设置，适应深色模式
- 调整了代码格式，提高了可读性

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **样式更新**
	- 更新了工具栏的选择器，确保在内容为空时隐藏元素。
	- 修改了图像选择器，使其在暗模式下的样式更具全球适用性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->