### PR TITLE
fix(SkinCitizen_CSS): 修复用户页工具栏样式

### DIFF
--- a/src/SkinCitizen_CSS/modules/fix-toolbar.less
+++ b/src/SkinCitizen_CSS/modules/fix-toolbar.less
@@ -6,7 +6,8 @@
 }
 
 // 更新toolbar样式，防止在无内容时显示。 by awajie
-#mw-content-subtitle {
+#mw-content-subtitle,
+.mw-undelete-subtitle {
 	.toolbar-fix();
 	&:empty {
 		display: none;


### PR DESCRIPTION
- 更新 toolbar 样式，防止在无内容时显示
- 新增对 mw-undelete-subtitle 类的样式应用

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 更新了工具栏的样式，新增了 `.mw-undelete-subtitle` 类，以改善外观和功能。
  - 当工具栏为空时，自动隐藏该元素，提升用户体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->