### PR TITLE
fix: 更新控制台和infobox中tabber拓展溢出问题

### DIFF
--- a/src/ConsolePrintWordartLogo/ConsolePrintWordartLogo.ts
+++ b/src/ConsolePrintWordartLogo/ConsolePrintWordartLogo.ts
@@ -1,0 +1,18 @@
+(async function () {
+	const consoleTUrl = `${mw.config.get('wgServer')}/api.php?action=query&meta=siteinfo&formatversion=2&format=json`;
+	const generatordata = await fetch(consoleTUrl);
+	const generatordataJson = (await generatordata.json()) as unknown;
+	const mediawikiVersions = (generatordataJson as {query: {general: {generator: string}}}).query.general.generator;
+	const ascii = `
+██╗     ██╗                 ██████╗ ██╗                                        ██╗██╗      ██╗
+╚██╗   ██╔╝                ██╔═══██╗██║                                        ╚═╝██║      ╚═╝
+ ╚██╗ ██╔╝██████╗ ██╗   ██╗██║   ╚═╝███████╗  ██████╗ ██╗   ██╗   ██╗  ██╗  ██╗██╗██║   ██╗██╗
+  ╚████╔╝██╔═══██╗██║   ██║╚██████╗ ██╔═══██╗██╔═══██╗██║   ██║   ██║  ██║  ██║██║██║  ██╔╝██║
+   ╚██╔╝ ██║   ██║██║   ██║ ╚════██║██║   ██║██║   ██║██║   ██║   ██║  ██║  ██║██║██████╔╝ ██║
+    ██║  ██║   ██║██║   ██║██    ██║██║   ██║██║   ██║██║   ██║   ██║  ██║  ██║██║██╔══██╗ ██║
+    ██║  ╚██████╔╝╚██████╔╝╚██████╔╝██║   ██║╚██████╔╝╚██████╔╝██╗╚█████ ████╔╝██║██║  ╚██╗██║
+    ╚═╝   ╚═════╝  ╚═════╝  ╚═════╝ ╚═╝   ╚═╝ ╚═════╝  ╚═════╝ ╚═╝ ╚═════╚═══╝ ╚═╝╚═╝   ╚═╝╚═╝
+    ©2023-${new Date().getFullYear()} 有兽档案馆                                                ${mediawikiVersions}
+    `;
+	console.log(`%c${ascii}`, 'color:#159c5a');
+})();

--- a/src/ConsolePrintWordartLogo/LICENSE
+++ b/src/ConsolePrintWordartLogo/LICENSE
@@ -1,0 +1,5 @@
+/**
+ * SPDX-License-Identifier: CC-BY-SA-4.0
+ * _addText: '{{Gadget Header|license=CC-BY-SA-4.0|import=no}}'
+ * @author 顶呱呱的阿杰 
+ */

--- a/src/ConsolePrintWordartLogo/definition.json
+++ b/src/ConsolePrintWordartLogo/definition.json
@@ -1,0 +1,9 @@
+{
+	"enable": true,
+	"description": "<sup><abbr title=\"默认为所有注册用户启用\">U</abbr></sup><span id=\"Gadget-NavbarAvatar\"></span> NavbarAvatar <small>在导航栏显示用户头像。</small>",
+	"section": "browser",
+	"default": true,
+	"dependencies": ["mediawiki.user"],
+	"hidden": true,
+	"rights": ["edit"]
+}

--- a/src/ConsolePrintWordartLogo/definition.json
+++ b/src/ConsolePrintWordartLogo/definition.json
@@ -1,9 +1,7 @@
 {
 	"enable": true,
-	"description": "<sup><abbr title=\"默认为所有注册用户启用\">U</abbr></sup><span id=\"Gadget-NavbarAvatar\"></span> NavbarAvatar <small>在导航栏显示用户头像。</small>",
+	"description": "<sup><abbr title=\"默认为所有用户启用\">U</abbr></sup><span id=\"Gadget-NavbarAvatar\"></span>ConsolePrintWordartLogo",
 	"section": "browser",
 	"default": true,
-	"dependencies": ["mediawiki.user"],
 	"hidden": true,
-	"rights": ["edit"]
 }

--- a/src/SkinCitizen_CSS/SkinCitizen_CSS.less
+++ b/src/SkinCitizen_CSS/SkinCitizen_CSS.less
@@ -9,6 +9,7 @@
 @import './modules/fix-site-icon.less';
 @import './modules/hide-sub.less';
 @import './modules/HYYouShouYan.less';
+@import './modules/infobox-tabber-overflow-repair.less';
 @import './modules/mobile-style.less';
 @import './modules/pages-style-repair.less';
 @import './modules/page-width.less';

--- a/src/SkinCitizen_CSS/modules/infobox-tabber-overflow-repair.less
+++ b/src/SkinCitizen_CSS/modules/infobox-tabber-overflow-repair.less
@@ -1,0 +1,18 @@
+// 修复tabber扩展在infobox中溢出的问题 by awajie
+.infobox {
+	tbody {
+		> tr:nth-child(1) {
+			td {
+				display: flex;
+				flex-direction: column;
+				overflow-x: auto;
+				.tabber__header .tabber__header__prev::after,
+				.tabber__header .tabber__header__next::after {
+					display: block;
+					width: 100%;
+					height: 100%;
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 引入了一个控制台打印的ASCII艺术标志，显示当前年份和MediaWiki生成器版本。
  - 添加了新的JSON配置文件以支持`NavbarAvatar`功能，默认启用并需要编辑权限。

- **样式**
  - 更新了CSS以解决信息框中的标签溢出问题，增强了视觉布局。

- **文档**
  - 在许可证文件中添加了版权声明和许可证类型信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->