### PR TITLE
fix: 修复暗模式css污染到别的页面

### DIFF
--- a/src/Mainpage_CSS/Mainpage.less
+++ b/src/Mainpage_CSS/Mainpage.less
@@ -61,28 +61,28 @@ html.client-darkmode .home-card {
 	margin-right: 0.3rem;
 }
 
-html.client-darkmode .mw-parser-output.mw-content-ltr::after {
-	background: linear-gradient(90deg, transparent, #1e1e1e, transparent);
-}
-
-// 主页主体图片不反色
-html.client-darkmode .mw-parser-output.mw-content-ltr img {
-	filter: none;
-	-webkit-filter: none;
-}
-
-// 主页主体部分在darkmode下不反色
-html.client-darkmode .mw-parser-output.mw-content-ltr {
-	filter: invert(1) hue-rotate(180deg);
-	-webkit-filter: invert(1) hue-rotate(180deg);
-	color: #fff;
-	background-color: rgba(30, 30, 30, 0.9);
-}
-
-// 主页主体部分图片不反色
-html.client-darkmode .mw-parser-output.mw-content-ltr .filter {
-	filter: invert(1) hue-rotate(180deg);
-	-webkit-filter: invert(1) hue-rotate(180deg);
+// 首页暗模式
+html.client-darkmode {
+	.page-有兽档案馆_首页,
+	.page-Template_首页 {
+		.mw-parser-output.mw-content-ltr::after {
+			background: linear-gradient(90deg, transparent, #1e1e1e, transparent);
+		}
+		.mw-parser-output.mw-content-ltr img {
+			filter: none;
+			-webkit-filter: none;
+		}
+		.mw-parser-output.mw-content-ltr {
+			filter: invert(1) hue-rotate(180deg);
+			-webkit-filter: invert(1) hue-rotate(180deg);
+			color: #fff;
+			background-color: rgba(30, 30, 30, 0.9);
+		}
+		.mw-parser-output.mw-content-ltr .filter {
+			filter: invert(1) hue-rotate(180deg);
+			-webkit-filter: invert(1) hue-rotate(180deg);
+		}
+	}
 }
 
 /* index body */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **样式**
	- 优化了暗黑模式下部分页面的样式组织，将分散的视觉效果整合到统一结构中，确保视觉表现与之前保持一致，同时提升了代码的维护性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->