### PR TITLE
fix:修复公告被背景模版挡住的问题

### DIFF
--- a/src/SiteCommon_SpecialInterface/modules/catlinks.less
+++ b/src/SiteCommon_SpecialInterface/modules/catlinks.less
@@ -1,3 +1,6 @@
 #catlinks {
 	z-index: 0;
 }
+#siteNotice {
+	z-index: 0;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - 修复站点公告与分类链接等元素在部分页面发生遮挡/覆盖的问题，确保内容可见并可点击。
- Style
  - 优化页面层级与视觉层次，站点公告不再压住其他内容，在滚动与固定布局下表现更一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->