### PR TITLE
更改档案馆背景图

### DIFF
--- a/src/SkinCitizen/modules/background.less
+++ b/src/SkinCitizen/modules/background.less
@@ -28,7 +28,7 @@ html::before {
 	width: 100%;
 	height: calc(100vh - var(--header-size));
 	margin-top: var(--header-size); // 避免顶栏挡住背景图的顶部
-	background: url('https://image.youshou.wiki/6/65/%E6%9C%89%E5%85%BD%E7%84%892026%E5%B9%B4%E5%85%83%E6%97%A6%E5%AE%98%E6%96%B9%E8%B4%BA%E5%9B%BE.jpg')
+	background: url('https://image.youshou.wiki/1/14/%E5%A4%A7%E6%9A%91%E8%8A%82%E6%B0%94%E5%9C%BA%E6%99%AF%E6%8F%92%E5%9B%BE%EF%BC%882026%EF%BC%89.jpg')
 		100% 0;
 	background-size: cover;
 }


### PR DESCRIPTION
更改档案馆背景图为大暑节气场景插图（2026）.jpg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **样式**
  * 更新页面背景图片资源，替换为 2026 年节气场景插图。
  * 保持原有背景布局、尺寸及深色模式显示效果不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->